### PR TITLE
Fix create_room method for RoomServiceClient

### DIFF
--- a/lib/livekit/room_service_client.rb
+++ b/lib/livekit/room_service_client.rb
@@ -16,7 +16,7 @@ module LiveKit
     def create_room(name, empty_timeout: nil, max_participants: nil)
       self.rpc(
         :CreateRoom,
-        Proto::ListRoomsRequest(name: name, empty_timeout: empty_timeout, max_participants: max_participants),
+        Proto::CreateRoomRequest.new(name: name, empty_timeout: empty_timeout, max_participants: max_participants),
         headers: auth_header(roomCreate: true),
       )
     end


### PR DESCRIPTION
Correction of the following error when try create room:
NoMethodError: undefined method `ListRoomsRequest' for LiveKit::Proto:Module