### PR TITLE
readme manager initial setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
+<!--BEGIN_BANNER_IMAGE--><!--END_BANNER_IMAGE-->
+
 # LiveKit Server API for Ruby
 
-Ruby API for server-side integrations with LiveKit. This gem provides the ability to create access tokens as well as access RoomService.
+Ruby API for server-side integrations with LiveKit. <!--BEGIN_DESCRIPTION--><!--END_DESCRIPTION-->
 
 This library is designed to work with Ruby 2.6.0 and above.
 
@@ -122,3 +124,6 @@ You may store credentials in environment variables. If api-key or api-secret is 
 ## License
 
 The gem is available as open source under the terms of Apache 2.0 License.
+
+<!--BEGIN_REPO_NAV--><!--END_REPO_NAV-->
+

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # LiveKit Server API for Ruby
 
 <!--BEGIN_DESCRIPTION-->
-Ruby API for server-side integrations with LiveKit.
+Ruby API for server-side integrations with LiveKit. This gem provides the ability to create access tokens as well as access RoomService.
 <!--END_DESCRIPTION-->
 
 This library is designed to work with Ruby 2.6.0 and above.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 # LiveKit Server API for Ruby
 
-Ruby API for server-side integrations with LiveKit. <!--BEGIN_DESCRIPTION--><!--END_DESCRIPTION-->
+<!--BEGIN_DESCRIPTION-->
+Ruby API for server-side integrations with LiveKit.
+<!--END_DESCRIPTION-->
 
 This library is designed to work with Ruby 2.6.0 and above.
 


### PR DESCRIPTION
This PR makes the README ready to be managed by the readme manager. It adds custom comment tags to the readme, which are invisible when the README is rendered, but tell the readme manager where to insert and update content.