### PR TITLE
fix exception: private method set_output' called for #<LiveKit::Egress…

### DIFF
--- a/lib/livekit/egress_service_client.rb
+++ b/lib/livekit/egress_service_client.rb
@@ -39,7 +39,7 @@ module LiveKit
         audio_only: audio_only,
         video_only: video_only,
       )
-      self.set_output(request, output)
+      set_output(request, output)
       self.rpc(
         :StartRoomCompositeEgress,
         request,
@@ -66,7 +66,7 @@ module LiveKit
         preset: preset,
         advanced: advanced,
       )
-      self.set_output(request, output)
+      set_output(request, output)
       self.rpc(
         :StartParticipantEgress,
         request,
@@ -94,7 +94,7 @@ module LiveKit
         audio_track_id: audio_track_id,
         video_track_id: video_track_id,
       )
-      self.set_output(request, output)
+      set_output(request, output)
       self.rpc(
         :StartTrackCompositeEgress,
         request,


### PR DESCRIPTION
fix exception:  […ServiceClient:0x000055f15cca5cf8>](https://github.com/livekit/server-sdk-ruby/issues/39)  :42

issue #39 https://github.com/livekit/server-sdk-ruby/issues/39