### PR TITLE
Some patches

### DIFF
--- a/lib/livekit/auth_mixin.rb
+++ b/lib/livekit/auth_mixin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module LiveKit
   # Create authenticated headers when keys are provided
   module AuthMixin

--- a/lib/livekit/egress_service_client.rb
+++ b/lib/livekit/egress_service_client.rb
@@ -9,7 +9,7 @@ module LiveKit
     attr_accessor :api_key, :api_secret
 
     def initialize(base_url, api_key: nil, api_secret: nil)
-      super(File.join(to_http_url(base_url), "/twirp"))
+      super(File.join(Utils.to_http_url(base_url), "/twirp"))
       @api_key = api_key
       @api_secret = api_secret
     end

--- a/lib/livekit/egress_service_client.rb
+++ b/lib/livekit/egress_service_client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "livekit/proto/livekit_egress_twirp"
 require "livekit/auth_mixin"
 require 'livekit/utils'

--- a/lib/livekit/grants.rb
+++ b/lib/livekit/grants.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module LiveKit
   class ClaimGrant
     attr_accessor :identity, :name, :metadata, :sha256, :video

--- a/lib/livekit/ingress_service_client.rb
+++ b/lib/livekit/ingress_service_client.rb
@@ -9,7 +9,7 @@ module LiveKit
     attr_accessor :api_key, :api_secret
 
     def initialize(base_url, api_key: nil, api_secret: nil)
-      super(File.join(to_http_url(base_url), "/twirp"))
+      super(File.join(Utils.to_http_url(base_url), "/twirp"))
       @api_key = api_key
       @api_secret = api_secret
     end

--- a/lib/livekit/room_service_client.rb
+++ b/lib/livekit/room_service_client.rb
@@ -9,7 +9,7 @@ module LiveKit
     attr_accessor :api_key, :api_secret
 
     def initialize(base_url, api_key: nil, api_secret: nil)
-      super(File.join(to_http_url(base_url), "/twirp"))
+      super(File.join(Utils.to_http_url(base_url), "/twirp"))
       @api_key = api_key
       @api_secret = api_secret
     end

--- a/lib/livekit/room_service_client.rb
+++ b/lib/livekit/room_service_client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "livekit/proto/livekit_room_twirp"
 require "livekit/auth_mixin"
 require 'livekit/utils'

--- a/lib/livekit/utils.rb
+++ b/lib/livekit/utils.rb
@@ -12,20 +12,6 @@ class ::Hash
     end
     Hash[h]
   end
-
-  # via https://stackoverflow.com/a/25835016/2257038
-  def symbol_keys
-    h = self.map do |k, v|
-      v_sym = if v.instance_of? Hash
-          v.symbol_keys
-        else
-          v
-        end
-
-      [k.to_sym, v_sym]
-    end
-    Hash[h]
-  end
 end
 
 # convert websocket urls to http

--- a/lib/livekit/utils.rb
+++ b/lib/livekit/utils.rb
@@ -16,12 +16,18 @@ unless Hash.method_defined?(:stringify_keys)
   end
 end
 
-# convert websocket urls to http
-def to_http_url(url)
-  if url.start_with?("ws")
-    # replace ws prefix to http
-    return url.sub(/^ws/, "http")
-  else
-    return url
+module LiveKit
+  module Utils
+    def to_http_url(url)
+      if url.start_with?("ws")
+        # replace ws prefix to http
+        return url.sub(/^ws/, "http")
+      else
+        return url
+      end
+    end
+
+    module_function :to_http_url
   end
 end
+# convert websocket urls to http

--- a/lib/livekit/utils.rb
+++ b/lib/livekit/utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 unless Hash.method_defined?(:stringify_keys)
   class Hash
     # via https://stackoverflow.com/a/25835016/2257038

--- a/lib/livekit/utils.rb
+++ b/lib/livekit/utils.rb
@@ -1,16 +1,18 @@
-class ::Hash
-  # via https://stackoverflow.com/a/25835016/2257038
-  def stringify_keys
-    h = self.map do |k, v|
-      v_str = if v.instance_of? Hash
-          v.stringify_keys
-        else
-          v
-        end
+unless Hash.method_defined?(:stringify_keys)
+  class Hash
+    # via https://stackoverflow.com/a/25835016/2257038
+    def stringify_keys
+      h = self.map do |k, v|
+        v_str = if v.instance_of? Hash
+            v.stringify_keys
+          else
+            v
+          end
 
-      [k.to_s, v_str]
+        [k.to_s, v_str]
+      end
+      Hash[h]
     end
-    Hash[h]
   end
 end
 


### PR DESCRIPTION
1. Don't override ActiveSupport's `Hash#stringify_keys` extension if `ActiveSupport` loaded
2. Remove unused `Hash#symbol_keys`
3. Don't pollute `Object` class
4. Add #frozen_string_literal