### PR TITLE
Amerov patch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     livekit-server-sdk (0.6.4)
-      google-protobuf (>= 3.21.0, < 4.0)
+      google-protobuf (>= 3.7.0, < 4.0)
       jwt (>= 2.2.3, < 3.0)
       rack (>= 2.2.3)
       twirp (>= 1.10.0, < 2.0)
@@ -17,6 +17,7 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
     google-protobuf (3.22.2)
+    google-protobuf (3.22.2-x86_64-linux)
     jwt (2.7.0)
     method_source (1.0.0)
     pry (0.14.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     livekit-server-sdk (0.6.4)
       google-protobuf (>= 3.21.0, < 4.0)
       jwt (>= 2.2.3, < 3.0)
-      rack (>= 2.2.3, < 3.0)
+      rack (>= 2.2.3)
       twirp (>= 1.10.0, < 2.0)
 
 GEM

--- a/lib/livekit/utils.rb
+++ b/lib/livekit/utils.rb
@@ -32,4 +32,3 @@ module LiveKit
     module_function :to_http_url
   end
 end
-# convert websocket urls to http

--- a/lib/livekit/utils.rb
+++ b/lib/livekit/utils.rb
@@ -32,3 +32,4 @@ module LiveKit
     module_function :to_http_url
   end
 end
+# convert websocket urls to http

--- a/livekit_server_sdk.gemspec
+++ b/livekit_server_sdk.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "google-protobuf", ">= 3.21.0", "< 4.0"
+  spec.add_dependency "google-protobuf", ">= 3.7.0", "< 4.0"
   spec.add_dependency "jwt", ">= 2.2.3", "< 3.0"
   # workaround for twirp 1.10.0 missing it
   spec.add_dependency 'rack', '>= 2.2.3'

--- a/livekit_server_sdk.gemspec
+++ b/livekit_server_sdk.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "google-protobuf", ">= 3.21.0", "< 4.0"
   spec.add_dependency "jwt", ">= 2.2.3", "< 3.0"
   # workaround for twirp 1.10.0 missing it
-  spec.add_dependency 'rack', '>= 2.2.3', "< 3.0"
+  spec.add_dependency 'rack', '>= 2.2.3'
   spec.add_dependency "twirp", ">= 1.10.0", "< 2.0"
 
   # For more information and examples about making a new gem, checkout our


### PR DESCRIPTION
fix issue:
```
 Could not find compatible versions

Because twirp >= 1.7.0 depends on google-protobuf >= 3.7.0, < 4.A
  and google-protobuf >= 3.21.0, < 4.A could not be found in rubygems repository https://rubygems.org/, cached gems or installed locally for any resolution platforms (x86_64-linux),
  twirp >= 1.7.0 requires google-protobuf >= 3.7.0, < 3.21.0.
And because every version of livekit-server-sdk depends on google-protobuf >= 3.21.0, < 4.0,
  twirp >= 1.7.0 is incompatible with livekit-server-sdk >= 0.
So, because every version of livekit-server-sdk depends on twirp >= 1.10.0, < 2.0
  and Gemfile depends on livekit-server-sdk >= 0,
  version solving has failed.
  ```