### PR TITLE
#56 Use refine to scope monkey patch to gem only

### DIFF
--- a/lib/livekit.rb
+++ b/lib/livekit.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 require "livekit/access_token"
+require "livekit/utils"
 require "livekit/grants"
 require "livekit/token_verifier"
-require "livekit/utils"
 require "livekit/version"
 
 # required since generated protobufs does use `require` instead of `require_relative`

--- a/lib/livekit/grants.rb
+++ b/lib/livekit/grants.rb
@@ -35,6 +35,8 @@ module LiveKit
   end
 
   class VideoGrant
+    using LiveKit::Utils::StringifyKeysRefinement
+
     attr_accessor :roomCreate, :roomJoin, :roomList, :roomRecord, :roomAdmin,
       :room, :canPublish, :canPublishSources, :canSubscribe, :canPublishData,
       :canUpdateOwnMetadata, :hidden, :recorder, :ingressAdmin
@@ -88,7 +90,7 @@ module LiveKit
     def self.from_hash(hash)
       return nil if hash.nil?
 
-      hash = hash.transform_keys(&:to_s)
+      hash = hash.stringify_keys
 
       VideoGrant.new(
         roomCreate: hash["roomCreate"],

--- a/lib/livekit/grants.rb
+++ b/lib/livekit/grants.rb
@@ -88,7 +88,7 @@ module LiveKit
     def self.from_hash(hash)
       return nil if hash.nil?
 
-      hash = hash.stringify_keys
+      hash = hash.transform_keys(&:to_s)
 
       VideoGrant.new(
         roomCreate: hash["roomCreate"],

--- a/lib/livekit/utils.rb
+++ b/lib/livekit/utils.rb
@@ -1,23 +1,5 @@
 # frozen_string_literal: true
 
-unless Hash.method_defined?(:stringify_keys)
-  class Hash
-    # via https://stackoverflow.com/a/25835016/2257038
-    def stringify_keys
-      h = self.map do |k, v|
-        v_str = if v.instance_of? Hash
-            v.stringify_keys
-          else
-            v
-          end
-
-        [k.to_s, v_str]
-      end
-      Hash[h]
-    end
-  end
-end
-
 module LiveKit
   module Utils
     def to_http_url(url)

--- a/lib/livekit/utils.rb
+++ b/lib/livekit/utils.rb
@@ -2,16 +2,25 @@
 
 module LiveKit
   module Utils
+    # Utility function to convert WebSocket URLs to HTTP URLs
     def to_http_url(url)
       if url.start_with?("ws")
-        # replace ws prefix to http
-        return url.sub(/^ws/, "http")
+        # Replace 'ws' prefix with 'http'
+        url.sub(/^ws/, "http")
       else
-        return url
+        url
       end
     end
-
     module_function :to_http_url
+
+    module StringifyKeysRefinement
+      refine Hash do
+        def stringify_keys
+          transform_keys(&:to_s).transform_values do |value|
+            value.is_a?(Hash) ? value.stringify_keys : value
+          end
+        end
+      end
+    end
   end
 end
-# convert websocket urls to http

--- a/spec/livekit/grants_spec.rb
+++ b/spec/livekit/grants_spec.rb
@@ -1,0 +1,100 @@
+require 'spec_helper'
+
+RSpec.describe LiveKit::ClaimGrant do
+  describe 'initialization' do
+    it 'initializes with nil attributes' do
+      claim_grant = LiveKit::ClaimGrant.new
+      expect(claim_grant.identity).to be_nil
+      expect(claim_grant.name).to be_nil
+      expect(claim_grant.metadata).to be_nil
+      expect(claim_grant.sha256).to be_nil
+      expect(claim_grant.video).to be_nil
+    end
+  end
+
+  describe '.from_hash' do
+    context 'when input is valid' do
+      let(:input_hash) do
+        {
+          'sub' => '123',
+          'name' => 'John Doe',
+          'metadata' => 'User data',
+          'sha256' => 'hashcode',
+          'video' => {}
+        }
+      end
+
+      it 'creates a ClaimGrant with proper attributes' do
+        claim_grant = LiveKit::ClaimGrant.from_hash(input_hash)
+        expect(claim_grant.identity).to eq('123')
+        expect(claim_grant.name).to eq('John Doe')
+        expect(claim_grant.metadata).to eq('User data')
+        expect(claim_grant.sha256).to eq('hashcode')
+        expect(claim_grant.video).to be_a(LiveKit::VideoGrant)
+      end
+    end
+
+    context 'when input is nil' do
+      it 'returns nil' do
+        expect(LiveKit::ClaimGrant.from_hash(nil)).to be_nil
+      end
+    end
+
+    context 'when input has symbol keys' do
+      let(:input_hash_with_symbols) do
+        {
+          roomCreate: true,
+          roomJoin: false,
+          roomList: true,
+          roomRecord: false,
+          roomAdmin: true,
+          "room": 'example_room',
+          "canPublish": true,
+          canPublishSources: ['video', 'audio'],
+          canSubscribe: true,
+          canPublishData: true,
+          canUpdateOwnMetadata: false,
+          hidden: false,
+          recorder: true,
+          ingressAdmin: true
+        }
+      end
+
+      it 'creates a VideoGrant with proper attributes using symbol keys' do
+        video_grant = LiveKit::VideoGrant.from_hash(input_hash_with_symbols)
+        expect(video_grant.roomCreate).to eq(true)
+        expect(video_grant.roomJoin).to eq(false)
+        expect(video_grant.roomList).to eq(true)
+        expect(video_grant.roomRecord).to eq(false)
+        expect(video_grant.roomAdmin).to eq(true)
+        expect(video_grant.room).to eq('example_room')
+        expect(video_grant.canPublish).to eq(true)
+        expect(video_grant.canPublishSources).to eq(['video', 'audio'])
+        expect(video_grant.canSubscribe).to eq(true)
+        expect(video_grant.canPublishData).to eq(true)
+        expect(video_grant.canUpdateOwnMetadata).to eq(false)
+        expect(video_grant.hidden).to eq(false)
+        expect(video_grant.recorder).to eq(true)
+        expect(video_grant.ingressAdmin).to eq(true)
+      end
+    end
+
+  end
+
+  describe '#to_hash' do
+    it 'converts attributes to a hash correctly' do
+      video_grant = LiveKit::VideoGrant.new
+      claim_grant = LiveKit::ClaimGrant.new
+      claim_grant.name = 'John Doe'
+      claim_grant.metadata = 'User data'
+      claim_grant.sha256 = 'hashcode'
+      claim_grant.video = video_grant
+
+      result = claim_grant.to_hash
+      expect(result[:name]).to eq('John Doe')
+      expect(result[:metadata]).to eq('User data')
+      expect(result[:sha256]).to eq('hashcode')
+      expect(result[:video]).to be_a(Hash)
+    end
+  end
+end


### PR DESCRIPTION
This PR aims to replace original monkey patch causing a  bug where gem is loaded before rails and then overrides the original rails `#stringify_keys`. It can also get in conflict with other gems using the `#stringify_keys` method coming from rails.