### PR TITLE
fix: auth header takes keyword argument not positional

### DIFF
--- a/lib/livekit/agent_dispatch_service_client.rb
+++ b/lib/livekit/agent_dispatch_service_client.rb
@@ -37,7 +37,7 @@ module LiveKit
       self.rpc(
         :CreateDispatch,
         request,
-        headers: auth_header(VideoGrant.new(roomAdmin: true, room: room_name)),
+        headers: auth_header(video_grant: VideoGrant.new(roomAdmin: true, room: room_name)),
       )
     end
 


### PR DESCRIPTION
Attempting to call Create Dispatch leads to the following error: 

`wrong number of arguments (given 1, expected 0) (ArgumentError)`

This is tracked down to the use of auth_header which expected keyword arguments not positional. 