### PR TITLE
use the correct client for agent dispatch service client

### DIFF
--- a/lib/livekit/agent_dispatch_service_client.rb
+++ b/lib/livekit/agent_dispatch_service_client.rb
@@ -6,7 +6,7 @@ module LiveKit
   # Client for LiveKit's Agent Dispatch Service, which manages agent assignments to rooms
   # This client handles creating, deleting, and retrieving agent dispatches
   class AgentDispatchServiceClient < Twirp::Client
-    client_for Proto::SIPService
+    client_for Proto::AgentDispatchServiceService
     include AuthMixin
     attr_accessor :api_key, :api_secret
 


### PR DESCRIPTION
The agent dispatch service is using the sip service client. This fixes it to use the correct one.


