### PR TITLE
Update google-protobuf and twirp dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,28 +2,35 @@ PATH
   remote: .
   specs:
     livekit-server-sdk (0.8.3)
-      google-protobuf (>= 3.21.0, < 4.0)
+      google-protobuf (~> 4.30, >= 4.30.2)
       jwt (>= 2.2.3, < 3.0)
-      rack (>= 2.2.3)
-      twirp (>= 1.10.0, < 2.0)
+      twirp (~> 1.13, >= 1.13.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     base64 (0.2.0)
+    bigdecimal (3.1.9)
     coderay (1.1.3)
     diff-lcs (1.5.0)
-    faraday (2.10.1)
-      faraday-net_http (>= 2.0, < 3.2)
+    faraday (2.13.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
       logger
-    faraday-net_http (3.1.1)
-      net-http
-    google-protobuf (3.25.4)
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
+    google-protobuf (4.30.2)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.30.2-x86_64-linux)
+      bigdecimal
+      rake (>= 13)
+    json (2.11.3)
     jwt (2.8.2)
       base64
-    logger (1.6.5)
+    logger (1.7.0)
     method_source (1.0.0)
-    net-http (0.4.1)
+    net-http (0.6.0)
       uri
     pry (0.14.2)
       coderay (~> 1.1)
@@ -31,8 +38,8 @@ GEM
     pry-doc (1.4.0)
       pry (~> 0.11)
       yard (~> 0.9.11)
-    rack (3.1.7)
-    rake (13.0.6)
+    rack (3.1.13)
+    rake (13.2.1)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -46,10 +53,11 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
-    twirp (1.10.0)
+    twirp (1.13.1)
       faraday (< 3)
-      google-protobuf (~> 3.0, >= 3.7.0)
-    uri (0.13.0)
+      google-protobuf (>= 3.25, < 5.a)
+      rack (>= 2.2.3)
+    uri (1.0.3)
     webrick (1.7.0)
     yard (0.9.28)
       webrick (~> 1.7.0)

--- a/livekit_server_sdk.gemspec
+++ b/livekit_server_sdk.gemspec
@@ -26,11 +26,9 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "google-protobuf", ">= 3.21.0", "< 4.0"
+  spec.add_dependency "google-protobuf", "~> 4.30", ">= 4.30.2"
   spec.add_dependency "jwt", ">= 2.2.3", "< 3.0"
-  # workaround for twirp 1.10.0 missing it
-  spec.add_dependency 'rack', '>= 2.2.3'
-  spec.add_dependency "twirp", ">= 1.10.0", "< 2.0"
+  spec.add_dependency "twirp", "~> 1.13", ">= 1.13.1"
 
   # For more information and examples about making a new gem, checkout our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
This PR updates **google-protobuf** and **twirp** to the latest version.

I performed some manual API calls to verify behavior and the full test suite passes, everything seems to work as expected.

Additionally, I removed rack from the gemspec since the latest version of twirp already includes it as a sub-dependency.