### PR TITLE
fix kwargs in AgentDispatchServiceClient

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    livekit-server-sdk (0.8.3)
+    livekit-server-sdk (0.9.0)
       google-protobuf (~> 4.30, >= 4.30.2)
       jwt (>= 2.2.3, < 3.0)
       twirp (~> 1.13, >= 1.13.1)
@@ -9,36 +9,33 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    base64 (0.2.0)
-    bigdecimal (3.1.9)
+    base64 (0.3.0)
+    bigdecimal (4.0.1)
     coderay (1.1.3)
     diff-lcs (1.5.0)
-    faraday (2.13.1)
+    faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.0)
-      net-http (>= 0.5.0)
-    google-protobuf (4.30.2)
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
+    google-protobuf (4.33.5)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.30.2-x86_64-linux)
-      bigdecimal
-      rake (>= 13)
-    json (2.11.3)
-    jwt (2.8.2)
+    json (2.18.1)
+    jwt (2.10.2)
       base64
     logger (1.7.0)
     method_source (1.0.0)
-    net-http (0.6.0)
-      uri
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
     pry-doc (1.4.0)
       pry (~> 0.11)
       yard (~> 0.9.11)
-    rack (3.1.13)
+    rack (3.2.4)
     rake (13.2.1)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -57,7 +54,7 @@ GEM
       faraday (< 3)
       google-protobuf (>= 3.25, < 5.a)
       rack (>= 2.2.3)
-    uri (1.0.3)
+    uri (1.1.1)
     webrick (1.7.0)
     yard (0.9.28)
       webrick (~> 1.7.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    livekit-server-sdk (0.9.0)
+    livekit-server-sdk (0.8.3)
       google-protobuf (~> 4.30, >= 4.30.2)
       jwt (>= 2.2.3, < 3.0)
       twirp (~> 1.13, >= 1.13.1)
@@ -9,33 +9,36 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    base64 (0.3.0)
-    bigdecimal (4.0.1)
+    base64 (0.2.0)
+    bigdecimal (3.1.9)
     coderay (1.1.3)
     diff-lcs (1.5.0)
-    faraday (2.14.1)
+    faraday (2.13.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.2)
-      net-http (~> 0.5)
-    google-protobuf (4.33.5)
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
+    google-protobuf (4.30.2)
       bigdecimal
       rake (>= 13)
-    json (2.18.1)
-    jwt (2.10.2)
+    google-protobuf (4.30.2-x86_64-linux)
+      bigdecimal
+      rake (>= 13)
+    json (2.11.3)
+    jwt (2.8.2)
       base64
     logger (1.7.0)
     method_source (1.0.0)
-    net-http (0.9.1)
-      uri (>= 0.11.1)
+    net-http (0.6.0)
+      uri
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
     pry-doc (1.4.0)
       pry (~> 0.11)
       yard (~> 0.9.11)
-    rack (3.2.4)
+    rack (3.1.13)
     rake (13.2.1)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -54,7 +57,7 @@ GEM
       faraday (< 3)
       google-protobuf (>= 3.25, < 5.a)
       rack (>= 2.2.3)
-    uri (1.1.1)
+    uri (1.0.3)
     webrick (1.7.0)
     yard (0.9.28)
       webrick (~> 1.7.0)

--- a/lib/livekit/agent_dispatch_service_client.rb
+++ b/lib/livekit/agent_dispatch_service_client.rb
@@ -53,7 +53,7 @@ module LiveKit
       self.rpc(
         :DeleteDispatch,
         request,
-        headers: auth_header(VideoGrant.new(roomAdmin: true, room: room_name)),
+        headers: auth_header(video_grant: VideoGrant.new(roomAdmin: true, room: room_name)),
       )
     end
 
@@ -69,7 +69,7 @@ module LiveKit
       res = self.rpc(
         :ListDispatch,
         request,
-        headers: auth_header(VideoGrant.new(roomAdmin: true, room: room_name)),
+        headers: auth_header(video_grant: VideoGrant.new(roomAdmin: true, room: room_name)),
       )
       if res.agent_dispatches.size > 0
         return res.agent_dispatches[0]
@@ -87,7 +87,7 @@ module LiveKit
       res = self.rpc(
         :ListDispatch,
         request,
-        headers: auth_header(VideoGrant.new(roomAdmin: true, room: room_name)),
+        headers: auth_header(video_grant: VideoGrant.new(roomAdmin: true, room: room_name)),
       )
       res.agent_dispatches
     end

--- a/spec/livekit/agent_dispatch_service_client_spec.rb
+++ b/spec/livekit/agent_dispatch_service_client_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe LiveKit::AgentDispatchServiceClient do
+  let(:base_url) { 'http://localhost:7880' }
+  let(:api_key) { 'test_api_key' }
+  let(:api_secret) { 'test_api_secret' }
+  let(:client) { described_class.new(base_url, api_key: api_key, api_secret: api_secret) }
+  let(:room_name) { 'test-room' }
+  let(:agent_name) { 'test-agent' }
+  let(:dispatch_id) { 'dispatch-123' }
+
+  describe '#create_dispatch' do
+    it 'calls auth_header with keyword arguments' do
+      expect(client).to receive(:auth_header).with(
+        video_grant: instance_of(LiveKit::VideoGrant)
+      ).and_call_original
+
+      # Mock the RPC call to avoid actual network request
+      allow(client).to receive(:rpc).and_return(
+        LiveKit::Proto::AgentDispatch.new(id: dispatch_id)
+      )
+
+      client.create_dispatch(room_name, agent_name)
+    end
+  end
+
+  describe '#delete_dispatch' do
+    it 'calls auth_header with keyword arguments' do
+      expect(client).to receive(:auth_header).with(
+        video_grant: instance_of(LiveKit::VideoGrant)
+      ).and_call_original
+
+      # Mock the RPC call to avoid actual network request
+      allow(client).to receive(:rpc).and_return(
+        LiveKit::Proto::AgentDispatch.new(id: dispatch_id)
+      )
+
+      client.delete_dispatch(dispatch_id, room_name)
+    end
+  end
+
+  describe '#get_dispatch' do
+    it 'calls auth_header with keyword arguments' do
+      expect(client).to receive(:auth_header).with(
+        video_grant: instance_of(LiveKit::VideoGrant)
+      ).and_call_original
+
+      # Mock the RPC call to avoid actual network request
+      allow(client).to receive(:rpc).and_return(
+        LiveKit::Proto::ListAgentDispatchResponse.new(
+          agent_dispatches: [LiveKit::Proto::AgentDispatch.new(id: dispatch_id)]
+        )
+      )
+
+      client.get_dispatch(dispatch_id, room_name)
+    end
+  end
+
+  describe '#list_dispatch' do
+    it 'calls auth_header with keyword arguments' do
+      expect(client).to receive(:auth_header).with(
+        video_grant: instance_of(LiveKit::VideoGrant)
+      ).and_call_original
+
+      # Mock the RPC call to avoid actual network request
+      allow(client).to receive(:rpc).and_return(
+        LiveKit::Proto::ListAgentDispatchResponse.new(
+          agent_dispatches: []
+        )
+      )
+
+      client.list_dispatch(room_name)
+    end
+  end
+
+  describe 'Ruby 3 compatibility' do
+    it 'does not raise ArgumentError when calling methods' do
+      # Mock the RPC calls
+      allow(client).to receive(:rpc).and_return(
+        LiveKit::Proto::AgentDispatch.new(id: dispatch_id)
+      )
+
+      expect { client.create_dispatch(room_name, agent_name) }.not_to raise_error
+      expect { client.delete_dispatch(dispatch_id, room_name) }.not_to raise_error
+
+      allow(client).to receive(:rpc).and_return(
+        LiveKit::Proto::ListAgentDispatchResponse.new(agent_dispatches: [])
+      )
+
+      expect { client.get_dispatch(dispatch_id, room_name) }.not_to raise_error
+      expect { client.list_dispatch(room_name) }.not_to raise_error
+    end
+  end
+end

--- a/spec/livekit/agent_dispatch_service_client_spec.rb
+++ b/spec/livekit/agent_dispatch_service_client_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe LiveKit::AgentDispatchServiceClient do
   describe '#create_dispatch' do
     it 'calls auth_header with keyword arguments' do
       expect(client).to receive(:auth_header).with(
-        video_grant: instance_of(LiveKit::VideoGrant)
+        video_grant: have_attributes(roomAdmin: true, room: room_name)
       ).and_call_original
 
       # Mock the RPC call to avoid actual network request


### PR DESCRIPTION
Some code changes were made to AgentDispatchServiceClient that broke on ruby 3 (but wouldve still worked in like, ruby2.7 I believe). This change patches those call to use proper keyword arguements. 