### PR TITLE
Fix delete/get/list_dispatch: keyword auth_header + ClientResp .data unwrap

### DIFF
--- a/lib/livekit/agent_dispatch_service_client.rb
+++ b/lib/livekit/agent_dispatch_service_client.rb
@@ -53,7 +53,7 @@ module LiveKit
       self.rpc(
         :DeleteDispatch,
         request,
-        headers: auth_header(VideoGrant.new(roomAdmin: true, room: room_name)),
+        headers: auth_header(video_grant: VideoGrant.new(roomAdmin: true, room: room_name)),
       )
     end
 
@@ -69,10 +69,10 @@ module LiveKit
       res = self.rpc(
         :ListDispatch,
         request,
-        headers: auth_header(VideoGrant.new(roomAdmin: true, room: room_name)),
+        headers: auth_header(video_grant: VideoGrant.new(roomAdmin: true, room: room_name)),
       )
-      if res.agent_dispatches.size > 0
-        return res.agent_dispatches[0]
+      if res.data.agent_dispatches.size > 0
+        return res.data.agent_dispatches[0]
       end
       nil
     end
@@ -87,9 +87,9 @@ module LiveKit
       res = self.rpc(
         :ListDispatch,
         request,
-        headers: auth_header(VideoGrant.new(roomAdmin: true, room: room_name)),
+        headers: auth_header(video_grant: VideoGrant.new(roomAdmin: true, room: room_name)),
       )
-      res.agent_dispatches
+      res.data.agent_dispatches
     end
   end
 end


### PR DESCRIPTION
## Problem

`AgentDispatchServiceClient#delete_dispatch`, `#get_dispatch`, and `#list_dispatch` are unusable as shipped:

1. **Positional grant → `ArgumentError`.** All three pass the grant positionally to `AuthMixin#auth_header`, which only accepts the `video_grant:` keyword:
   ```ruby
   headers: auth_header(VideoGrant.new(roomAdmin: true, room: room_name))
   ```
   Every call raises `ArgumentError: wrong number of arguments (given 1, expected 0)` from `auth_mixin.rb` before any request is sent. `#create_dispatch` is the only method that passes the keyword correctly.

2. **`res.agent_dispatches` off a `ClientResp`.** `#get_dispatch` / `#list_dispatch` read `res.agent_dispatches` directly off the `Twirp::ClientResp` returned by `rpc`, instead of `res.data.agent_dispatches` — a `NoMethodError` that the first bug masked.

## Fix

Minimal: pass `video_grant:` and unwrap `res.data` in the three methods. `#create_dispatch` is unchanged.

## Verification

Against a live LiveKit server: `create_dispatch` → `list_dispatch` (shows the dispatch) → `delete_dispatch` → `list_dispatch` (gone), all returning cleanly. Before the fix each of the three raised `ArgumentError` from `auth_mixin.rb`.
