### PR TITLE
server-sdk-ruby: add unified start_egress convenience method

### DIFF
--- a/lib/livekit/egress_service_client.rb
+++ b/lib/livekit/egress_service_client.rb
@@ -178,6 +178,44 @@ module LiveKit
       )
     end
 
+    def start_egress(
+      room_name: nil,
+      # source, only one of template, web or media could be set
+      # TemplateSource
+      template: nil,
+      # WebSource
+      web: nil,
+      # MediaSource
+      media: nil,
+      # EncodingOptionsPreset, only one of preset or advanced could be set
+      preset: nil,
+      # EncodingOptions, only one of preset or advanced could be set
+      advanced: nil,
+      # an Output or array of Output
+      outputs: nil,
+      # StorageConfig, default storage for outputs that don't set their own
+      storage: nil,
+      # list of extra webhooks to call for this request
+      webhooks: nil
+    )
+      request = Proto::StartEgressRequest.new(
+        room_name: room_name,
+        template: template,
+        web: web,
+        media: media,
+        preset: preset,
+        advanced: advanced,
+        outputs: outputs.nil? ? nil : Array(outputs),
+        storage: storage,
+        webhooks: webhooks,
+      )
+      rpc!(
+        :StartEgress,
+        request,
+        headers:auth_header(video_grant: VideoGrant.new(roomRecord: true)),
+      )
+    end
+
     def update_layout(egress_id, layout)
       rpc!(
         :UpdateLayout,

--- a/spec/api/livekit_api_spec.rb
+++ b/spec/api/livekit_api_spec.rb
@@ -89,6 +89,14 @@ RSpec.describe LiveKit::LiveKitAPI do
       api.egress.start_track_composite_egress('test-room', mp4.call,
                                               audio_track_id: 'TR_audio1', video_track_id: 'TR_video1')
       api.egress.start_track_egress('test-room', PB::DirectFileOutput.new(filepath: 'track.mp4'), 'TR_video1')
+      api.egress.start_egress(
+        room_name: 'test-room',
+        media: PB::MediaSource.new(video_track_id: 'TR_video1'),
+        outputs: PB::Output.new(
+          file: PB::FileOutput.new(file_type: PB::EncodedFileType::MP4, filepath: 'out.mp4')
+        ),
+        preset: PB::EncodingOptionsPreset::H264_1080P_30
+      )
       api.egress.update_layout('EG_abc123', 'speaker')
       api.egress.update_stream('EG_abc123', add_output_urls: ['rtmps://b.example.com/live/key'],
                                             remove_output_urls: ['rtmps://a.example.com/live/key'])


### PR DESCRIPTION
server-sdk-ruby's EgressServiceClient exposes a unified start_egress that calls the Egress.StartEgress Twirp RPC with the v2 StartEgressRequest.
