### PR TITLE
Require exp when verifying access tokens

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     livekit-server-sdk (1.0.0)
       faraday (>= 2.0, < 3.0)
       google-protobuf (~> 4.30, >= 4.30.2)
-      jwt (>= 2.2.3, < 3.0)
+      jwt (>= 2.3.0, < 3.0)
       twirp (~> 1.13, >= 1.13.1)
 
 GEM

--- a/lib/livekit/token_verifier.rb
+++ b/lib/livekit/token_verifier.rb
@@ -10,7 +10,15 @@ module LiveKit
     end
 
     def verify(token)
-      decoded_token = JWT.decode(token, @api_secret, true, algorithm: AccessToken::SIGNING_ALGORITHM)
+      decoded_token = JWT.decode(
+        token,
+        @api_secret,
+        true,
+        {
+          algorithm: AccessToken::SIGNING_ALGORITHM,
+          required_claims: ["exp"],
+        },
+      )
       decoded = decoded_token.first
       if decoded["iss"] != @api_key
         raise "Invalid issuer"

--- a/livekit_server_sdk.gemspec
+++ b/livekit_server_sdk.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday", ">= 2.0", "< 3.0"
   spec.add_dependency "google-protobuf", "~> 4.30", ">= 4.30.2"
-  spec.add_dependency "jwt", ">= 2.2.3", "< 3.0"
+  spec.add_dependency "jwt", ">= 2.3.0", "< 3.0"
   spec.add_dependency "twirp", "~> 1.13", ">= 1.13.1"
 
   # For more information and examples about making a new gem, checkout our

--- a/spec/livekit/token_verifier_spec.rb
+++ b/spec/livekit/token_verifier_spec.rb
@@ -17,6 +17,18 @@ RSpec.describe LiveKit::TokenVerifier do
     expect(grant.attributes["mykey"]).to eq("myvalue")
   end
 
+  it "fails when exp is missing" do
+    payload = {
+      "iss" => TEST_KEY,
+      "sub" => "user",
+      "nbf" => Time.now.to_i - 5,
+      "video" => { "roomJoin" => true, "room" => "testroom" },
+    }
+    jwt = JWT.encode(payload, TEST_SECRET, "HS256")
+    v = described_class.new(api_key: TEST_KEY, api_secret: TEST_SECRET)
+    expect { v.verify(jwt) }.to raise_error(JWT::MissingRequiredClaim)
+  end
+
   it "fails on expired tokens" do
     token = LiveKit::AccessToken.new(api_key: TEST_KEY, api_secret: TEST_SECRET,
                                      identity: "test_identity", ttl: -10)


### PR DESCRIPTION
## Summary

`TokenVerifier#verify` called `JWT.decode` without `required_claims`. ruby-jwt only checks `exp` when the claim is present, so a valid HS256 token with no `exp` never expired.

This sets `required_claims: ["exp"]`. Language-split of livekit/protocol#1706, livekit/python-sdks#779, and livekit/node-sdks#710. Distinct from #88 (jwt 3.x bump).

## Test plan

- [x] `bundle exec rspec` 23 examples, 0 failures (2 pending mock-server)
- [x] New case: signed token with no `exp` raises `JWT::MissingRequiredClaim`
- [x] Revert-test: drop `required_claims` and that case fails (token is accepted)

Made with [Cursor](https://cursor.com)